### PR TITLE
#161983635 Implement get a single user profile feature

### DIFF
--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -269,6 +269,47 @@ class UsersController {
         next(err);
       });
   }
+
+  /**
+   * @description - This method gets a single user profile
+   * @param {object} req The express request object
+   * @param {object} res The express response object
+   * @param {object} next The express next object
+   * @returns {void}
+   */
+  static async getSingleProfile(req, res, next) {
+    // requester id
+    const requesterId = req.userData.id;
+    // profile id
+    const { userId } = req.params;
+
+    let userProfile;
+    try {
+      // get the single user by id
+      userProfile = await User.findByPk(userId, {
+        raw: true,
+      });
+    } catch (err) {
+      next(err);
+    }
+
+    // delete unneeded information
+    delete userProfile.facebookId;
+    delete userProfile.twitterId;
+    delete userProfile.googleId;
+
+    // check if the requester is not the owner of the user profile
+    if (requesterId !== +userId) {
+      // delete sensitive information
+      delete userProfile.email;
+      delete userProfile.updatedAt;
+    }
+
+    return res.status(200).json({
+      status: 'success',
+      userProfile,
+    });
+  }
 }
 
 export default UsersController;

--- a/server/middlewares/confirmUser.js
+++ b/server/middlewares/confirmUser.js
@@ -9,7 +9,7 @@ const confirmUser = async (req, res, next) => {
   try {
     user = await User.findByPk(id);
   } catch (error) {
-    next(error);
+    return next(error);
   }
 
   if (!user.dataValues.confirmEmail) {

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -8,6 +8,6 @@ import bookmarks from './bookmarks';
 
 const router = express.Router();
 
-router.use('/', users, articles, comments, ratings, bookmarks);
+router.use('/', bookmarks, users, articles, comments, ratings);
 
 export default router;

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -22,6 +22,7 @@ const {
   userLoginEnd,
   verifyUser,
   updateProfile,
+  getSingleProfile,
   getUserProfiles,
 } = UserController;
 const {
@@ -81,6 +82,12 @@ router.get('/auth/google/callback', googlePassportRoutes.callback());
 
 // get all user profiles
 router.get('/users', verifyToken, confirmUser, getUserProfiles);
+
+// get a single user profile
+router.get(
+  '/users/:userId',
+  verifyToken, validateResourceId, confirmUser, getSingleProfile,
+);
 
 router.post(
   '/users/follow/:authorId',

--- a/test/server/controllers/UserController.test.js
+++ b/test/server/controllers/UserController.test.js
@@ -4,7 +4,7 @@ import chai from 'chai';
 import app from '../../../app';
 import { createToken } from '../../../server/middlewares/tokenUtils';
 
-chai.should();
+const should = chai.should();
 
 chai.use(chaiHttp);
 const signupUrl = '/api/v1/users/signup';
@@ -414,6 +414,57 @@ describe('Update user profile', () => {
       resData.body.status.should.equal('failure');
       resData.body.errors.message.should
         .equal('Sorry, that user was not found');
+    });
+  });
+});
+
+// GET A USER PROFILE
+describe('Get user profile', () => {
+  describe('for my own profile', () => {
+    const result = {};
+    before((done) => {
+      // get my profile
+      chai.request(app)
+        .get(`/api/v1/users/${userData.id}`)
+        .set('authorization', userData.token)
+        .end((err, res) => {
+          result.status = res.status;
+          result.body = res.body;
+          done();
+        });
+    });
+    it('should have a status of 200', () => {
+      result.status.should.be.equal(200);
+    });
+    it('should have a response containing all the users attributes', () => {
+      result.body.status.should.be.equal('success');
+      result.body.userProfile.id.should.be.equal(userData.id);
+      result.body.userProfile.bio.should.be.equal(updateData.bio);
+    });
+  });
+
+  describe('for another user\'s profile', () => {
+    const result = {};
+    before((done) => {
+      // get my profile
+      chai.request(app)
+        .get(`/api/v1/users/${userData.id - 1}`)
+        .set('authorization', userData.token)
+        .end((err, res) => {
+          result.status = res.status;
+          result.body = res.body;
+          done();
+        });
+    });
+    it('should have a status of 200', () => {
+      result.status.should.be.equal(200);
+    });
+    it('should have a response body with only public attributes', () => {
+      result.body.status.should.be.equal('success');
+      should.equal(result.body.userProfile.email, undefined);
+      should.equal(result.body.userProfile.googleId, undefined);
+      should.equal(result.body.userProfile.facebookId, undefined);
+      should.equal(result.body.userProfile.twitterId, undefined);
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Build the route to get a single user's profile

#### Description of Task to be completed?
- add endpoint to get a user's profile
- ensure user profile does not return sensitive information when being requested by another user

#### How should this be manually tested?
- clone the repository, cd into it, checkout this branch `feature/161983635/get-single-user-profile`
- set up your .env variables and local database
- run `npm install` to install required packages
- run `npm start` to start up the server
- use postman(or any api testing tool) to test the following routes route
- create a user using the route `POST http://localhost:3000/api/v1/users/signup` providing necessary request body.
- get a user profile with the route `POST http://localhost:3000/api/v1/users/:userId` providing the token in the `Authorization` header as shown in screen shots below.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[161983635](https://www.pivotaltracker.com/story/show/161983635)

#### Screenshots (if appropriate)
My profile:
<img width="792" alt="screen shot 2018-11-19 at 11 08 56 am" src="https://user-images.githubusercontent.com/31810086/48700528-7b67a780-ebec-11e8-95b7-a5b42382bb75.png">

Other profile:
<img width="826" alt="screen shot 2018-11-16 at 9 16 58 pm" src="https://user-images.githubusercontent.com/31810086/48645143-1c841180-e9e5-11e8-84ce-0a13d94d475d.png">


#### Questions:
N/A