### PR TITLE
#161291026 enable reading stats

### DIFF
--- a/server/controllers/ArticleController.js
+++ b/server/controllers/ArticleController.js
@@ -103,10 +103,10 @@ class ArticleController {
  * @description
  * @param {object} req - request object
  * @param {object} res - response object
- * @param {object} message - variable message
+ * @param {function} next - response object
  * @returns {object} - returns an Article
  */
-  static getAnArticle(req, res) {
+  static getAnArticle(req, res, next) {
     const { slug } = req.params;
     Article.findOne({
       where: {
@@ -136,10 +136,11 @@ class ArticleController {
         }
         const addMeta = await addMetaToArticle([result]);
         const article = cleanupArticlesResponse(addMeta);
-        return res.status(200).json({
+        res.status(200).json({
           status: 'success',
           article: article[0]
         });
+        return next();
       })
       .catch(err => res.status(500).json({
         status: 'failure',

--- a/server/middlewares/addReadingStats.js
+++ b/server/middlewares/addReadingStats.js
@@ -1,0 +1,48 @@
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import models from '../models';
+
+dotenv.config();
+
+const { ReadingStats, User } = models;
+
+/**
+ *
+ * @param {object} req - request object
+ * @param {object} res - response object
+ * @param {function} next - call next function
+ * @returns {void}
+ */
+
+// eslint-disable-next-line no-unused-vars
+const addReadingStats = (req, res, next) => {
+  const { authorization } = req.headers;
+  const { slug } = req.params;
+  if (authorization) {
+    const { id } = jwt.verify(authorization, process.env.JWT_SECRET);
+    ReadingStats
+      .findOrCreate({
+        where: {
+          articleId: +slug,
+          userId: id
+        }
+      })
+      .spread(async (stats, created) => {
+        if (created) {
+          // fetch user information
+          const userInfo = await User.findByPk(id);
+          const { articlesRead } = userInfo.dataValues;
+          // update user articlesRead count
+          await User.update({
+            articlesRead: articlesRead + 1
+          }, {
+            where: {
+              id
+            }
+          });
+        }
+      });
+  }
+};
+
+export default addReadingStats;

--- a/server/migrations/20181029191911-create-user.js
+++ b/server/migrations/20181029191911-create-user.js
@@ -57,6 +57,11 @@ export default {
       allowNull: true,
       type: Sequelize.BOOLEAN
     },
+    articlesRead: {
+      allowNull: true,
+      type: Sequelize.INTEGER,
+      defaultValue: 0,
+    },
     twitterUrl: {
       allowNull: true,
       type: Sequelize.STRING,

--- a/server/migrations/20181116191339-create-reading-stats.js
+++ b/server/migrations/20181116191339-create-reading-stats.js
@@ -1,0 +1,39 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable(
+    'ReadingStats', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        onDelete: 'CASCADE',
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id'
+        }
+      },
+      articleId: {
+        type: Sequelize.INTEGER,
+        onDelete: 'CASCADE',
+        allowNull: false,
+        references: {
+          model: 'Articles',
+          key: 'id'
+        }
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    }
+  ),
+  down: queryInterface => queryInterface.dropTable('ReadingStats')
+};

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -35,7 +35,8 @@ export default (sequelize, DataTypes) => {
       Rating,
       Category,
       ArticleTag,
-      Bookmark
+      Bookmark,
+      ReadingStats
     } = models;
     Article.belongsTo(User, {
       as: 'author',
@@ -64,6 +65,9 @@ export default (sequelize, DataTypes) => {
     });
     Article.hasMany(ArticleTag, {
       foreignKey: 'articleId',
+    });
+    Article.hasMany(ReadingStats, {
+      foreignKey: 'userId'
     });
   };
   return Article;

--- a/server/models/readingstats.js
+++ b/server/models/readingstats.js
@@ -1,0 +1,22 @@
+export default (sequelize, DataTypes) => {
+  const ReadingStats = sequelize.define('ReadingStats', {
+    userId: {
+      allowNull: false,
+      type: DataTypes.INTEGER
+    },
+    articleId: {
+      allowNull: false,
+      type: DataTypes.INTEGER
+    }
+  }, {});
+  ReadingStats.associate = (models) => {
+    const { User, Article } = models;
+    ReadingStats.belongsTo(User, {
+      foreignKey: 'userId'
+    });
+    ReadingStats.belongsTo(Article, {
+      foreignKey: 'articleId'
+    });
+  };
+  return ReadingStats;
+};

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -33,6 +33,11 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },
+    articlesRead: {
+      allowNull: true,
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+    },
     twitterUrl: {
       allowNull: true,
       type: DataTypes.STRING,
@@ -66,7 +71,8 @@ export default (sequelize, DataTypes) => {
       Rating,
       CommentLike,
       Follow,
-      Bookmark
+      Bookmark,
+      ReadingStats
     } = models;
 
     User.belongsTo(Role, {
@@ -104,6 +110,9 @@ export default (sequelize, DataTypes) => {
     });
     User.hasMany(Bookmark, {
       as: 'myBookmarks',
+      foreignKey: 'userId'
+    });
+    User.hasMany(ReadingStats, {
       foreignKey: 'userId'
     });
   };

--- a/server/routes/api/articles.js
+++ b/server/routes/api/articles.js
@@ -5,6 +5,7 @@ import ArticleController from '../../controllers/ArticleController';
 import ArticleValidation from '../../middlewares/ArticleValidation';
 import validateResourceId from '../../middlewares/validateResourceId';
 import queryGenerator from '../../middlewares/QueryGenerator';
+import addReadingStats from '../../middlewares/addReadingStats';
 
 const articles = express.Router();
 
@@ -26,6 +27,18 @@ articles.post(
   validateArticleInput,
   createArticle
 );
+articles.post(
+  '/articles',
+  verifyToken,
+  validateArticleInput,
+  createArticle
+);
+
+articles.get(
+  '/articles/:slug',
+  getAnArticle,
+  addReadingStats
+);
 
 // get all articles, search articles, filter articles
 articles.get(
@@ -35,11 +48,6 @@ articles.get(
   fetchAllArticles
 );
 
-// get article by slug or id
-articles.get(
-  '/articles/:slug',
-  getAnArticle
-);
 // like or dislike articles
 articles.post(
   '/articles/:articleId/reaction/:action',

--- a/test/server/controllers/ArticleController.test.js
+++ b/test/server/controllers/ArticleController.test.js
@@ -7,6 +7,7 @@ import {
   articleInputNoTitle,
   articleInputInvalidTags
 } from '../../../mockdata/articleMockData';
+import { createToken } from '../../../server/middlewares/tokenUtils';
 
 const should = chai.should();
 
@@ -282,7 +283,8 @@ describe('Articles Controller Tests', () => {
         });
     });
     it('Should return an article by slug', (done) => {
-      chai.request(app).get(getAnArticleUrl('south-africa-201'))
+      chai.request(app)
+        .get(getAnArticleUrl('south-africa-201'))
         .end((err, res) => {
           res.status.should.be.eql(200);
           res.body.article.id.should.be.eql(2);
@@ -297,7 +299,9 @@ describe('Articles Controller Tests', () => {
         });
     });
     it('Should return an article by id', (done) => {
+      const token = createToken(1, '24h');
       chai.request(app).get(getAnArticleUrl(2))
+        .set('authorization', token)
         .end((err, res) => {
           res.status.should.be.eql(200);
           res.body.article.id.should.be.eql(2);

--- a/test/server/middlewares/addReadingStats.test.js
+++ b/test/server/middlewares/addReadingStats.test.js
@@ -1,0 +1,30 @@
+import chaiHttp from 'chai-http';
+import chai from 'chai';
+
+import models from '../../../server/models';
+
+const { User, ReadingStats } = models;
+
+chai.use(chaiHttp);
+
+describe('should increase readStats by 1', () => {
+  let read;
+  let statsArticleId;
+  let statsUserId;
+  before(async () => {
+    const result = await User
+      .findByPk(1);
+    const user = await ReadingStats
+      .findByPk(1);
+    const { articlesRead } = result.dataValues;
+    const { articleId, userId } = user.dataValues;
+    statsArticleId = articleId;
+    statsUserId = userId;
+    read = articlesRead;
+  });
+  it('should return 1 as readingStats', () => {
+    read.should.be.equal(1);
+    statsUserId.should.be.equal(1);
+    statsArticleId.should.be.equal(2);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Enable users to be able to know their reading stats

#### Description of Task to be completed?
- enable readingStats on user table
- create readingStats model
- create readingStats migration
- add test for readingStats
- add reading stats in user model
- add reading stats in user migrations
- add middleware for readingStats

#### How should this be manually tested?
- clone this repo
- run `npm i`
- run `npm start`
- run `npm run db-init`
- sign up
- add your token to the header with key `authorization`
- fetch an article

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#161291026](https://www.pivotaltracker.com/story/show/161291026)

#### Screenshots (if appropriate)
Reading Stats Table populated
<img width="666" alt="screen shot 2018-11-17 at 1 42 15 am" src="https://user-images.githubusercontent.com/30160407/48654061-0fc5e480-ea0a-11e8-9c39-8bf6980e78f8.png">

Reading Stats column populated in the users table
<img width="518" alt="screen shot 2018-11-17 at 1 41 55 am" src="https://user-images.githubusercontent.com/30160407/48654232-70a1ec80-ea0b-11e8-9d17-a1740d387012.png">


#### Questions:

N/A