### PR TITLE
#162008174 Bug fix - Fix article like and dislike responses

### DIFF
--- a/server/controllers/ArticleController.js
+++ b/server/controllers/ArticleController.js
@@ -219,6 +219,8 @@ class ArticleController {
         return res.status(201).json({
           status: 'success',
           message: `article successfully ${suffix}d`,
+          articleLikeStatus: true,
+          type: suffix
         });
       }
 
@@ -236,6 +238,8 @@ class ArticleController {
           return res.status(200).json({
             status: 'success',
             message: `you changed your mind, article successfully ${suffix}d`,
+            articleLikeStatus: true,
+            type: suffix
           });
         }
       }
@@ -248,7 +252,9 @@ class ArticleController {
       if (undoRows > 0) {
         return res.status(200).json({
           status: 'success',
-          message: `article ${suffix}, undo successful`,
+          message: `article ${suffix} reversed successfully`,
+          articleLikeStatus: false,
+          type: suffix
         });
       }
     };

--- a/test/server/controllers/ArticleController.test.js
+++ b/test/server/controllers/ArticleController.test.js
@@ -376,7 +376,8 @@ describe('Articles Controller Tests', () => {
       });
       it('should return a success message', () => {
         result.body.status.should.be.equal('success');
-        result.body.message.should.be.equal('article like, undo successful');
+        result.body.message.should.be
+          .equal('article like reversed successfully');
       });
     });
 
@@ -420,7 +421,8 @@ describe('Articles Controller Tests', () => {
       });
       it('should return a success message', () => {
         result.body.status.should.be.equal('success');
-        result.body.message.should.be.equal('article dislike, undo successful');
+        result.body.message.should.be
+          .equal('article dislike reversed successfully');
       });
     });
 


### PR DESCRIPTION
#### What does this PR do?

Fix the response message for article like/dislike and like/dislike reversal.

#### Description of Task to be completed?

- add dislike type and articleLikeStatus to response
- update article controller test

#### How should this be manually tested?

- Clone the repo and cd into the project directory
- Set up your .env variables and local database
- run npm install to install required packages
- run `npm start` to fire up the server
- use postman(or any API testing tool) to test the following routes
  - http://localhost:3000/api/v1/articles/3/reaction/like
  - http://localhost:3000/api/v1/articles/3/reaction/dislike

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

[#162008174](https://www.pivotaltracker.com/story/show/162008174)

#### Screenshots (if appropriate)

<img width="1440" alt="screen shot 2018-11-18 at 4 16 18 pm" src="https://user-images.githubusercontent.com/15168965/48674501-52440a00-eb4d-11e8-9046-a214b9c19083.png">

<img width="1440" alt="screen shot 2018-11-18 at 4 13 19 pm" src="https://user-images.githubusercontent.com/15168965/48674467-fd07f880-eb4c-11e8-99b9-c3da6dcef681.png">

<img width="1440" alt="screen shot 2018-11-18 at 4 13 34 pm" src="https://user-images.githubusercontent.com/15168965/48674466-fd07f880-eb4c-11e8-9c0a-7525d686c304.png">

<img width="1440" alt="screen shot 2018-11-18 at 4 13 47 pm" src="https://user-images.githubusercontent.com/15168965/48674465-fd07f880-eb4c-11e8-94aa-bbc3127d4006.png">

<img width="1440" alt="screen shot 2018-11-18 at 4 13 11 pm" src="https://user-images.githubusercontent.com/15168965/48674468-fd07f880-eb4c-11e8-9036-ae5da017a1bb.png">

#### Questions:

N/A
